### PR TITLE
update: port number manipulation based on non-deprecated property

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1226,8 +1226,10 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     } else {
       url.append(serverName);
     }
-    if (portNumber != 0) {
-      url.append(":").append(portNumber);
+    // portNumber is deprecated. Manipulation based on that wouldn't reflect the actual value
+    if (portNumbers.length > 0) {
+      Arrays.stream(portNumbers).filter(num -> num > 0).findFirst()
+          .ifPresent(port -> url.append(":").append(port));
     }
     String moreEndPoints = getAdditionalEndPoints();
     if (moreEndPoints != null) {


### PR DESCRIPTION
`portNumber` property is deprecated and is never set as part of the set() call. If the underlying data source implementation doesn't explicitly set the PG_** port variable property, then the portNumber would always go as zero and get replaced with the default 5433. This is problematic in implementations where we test the driver integration using TestContainers. In such cases, the DB port would be mapped to the local container port (that may not be 5433) that gets set properly in `portNumbers[]` property instead of `portNumber`. Updated the logic to refer to `portNumbers[]` instead of `portNumber`.