### PR TITLE
Add custom hostnameverifier for YBM SSL Connectivity

### DIFF
--- a/pgjdbc/src/main/java/com/yugabyte/ysql/YBManagedHostnameVerifier.java
+++ b/pgjdbc/src/main/java/com/yugabyte/ysql/YBManagedHostnameVerifier.java
@@ -121,6 +121,7 @@ public class YBManagedHostnameVerifier implements HostnameVerifier {
     ArrayList<String> hostlist = new ArrayList<>();
     try {
       hostlist = getCurrentServers(controlConnection);
+      controlConnection.close();
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }

--- a/pgjdbc/src/main/java/com/yugabyte/ysql/YBManagedHostnameVerifier.java
+++ b/pgjdbc/src/main/java/com/yugabyte/ysql/YBManagedHostnameVerifier.java
@@ -41,7 +41,7 @@ public class YBManagedHostnameVerifier implements HostnameVerifier {
   protected Map<String, String> hostPortMap = new HashMap<>();
   protected Map<String, String> hostPortMapPublic = new HashMap<>();
   private final PGStream stream;
-  private Connection controlConnection = null;
+  private static Connection controlConnection = null;
 
   public YBManagedHostnameVerifier(Properties props, PGStream stream){
     this.originalProperties = props;

--- a/pgjdbc/src/main/java/com/yugabyte/ysql/YBManagedHostnameVerifier.java
+++ b/pgjdbc/src/main/java/com/yugabyte/ysql/YBManagedHostnameVerifier.java
@@ -42,7 +42,6 @@ public class YBManagedHostnameVerifier implements HostnameVerifier {
   protected Map<String, String> hostPortMapPublic = new HashMap<>();
   private final PGStream stream;
   private static Connection controlConnection = null;
-  private static String originalHost = null;
 
   public YBManagedHostnameVerifier(Properties props, PGStream stream){
     this.originalProperties = props;
@@ -113,8 +112,7 @@ public class YBManagedHostnameVerifier implements HostnameVerifier {
     originalProperties.setProperty("PGHOST", san);
     HostSpec[] hspec = hostSpecs(this.originalProperties);
     try {
-      if (controlConnection == null || ((PgConnection) controlConnection).getQueryExecutor().getHostSpec().getHost().equals(originalHost)) {
-        originalHost = san;
+      if (controlConnection == null) {
         controlConnection = new PgConnection(
             hspec, originalProperties.getProperty("user", ""), originalProperties.getProperty("PGDBNAME", ""), originalProperties, null);
       }

--- a/pgjdbc/src/main/java/com/yugabyte/ysql/YBManagedHostnameVerifier.java
+++ b/pgjdbc/src/main/java/com/yugabyte/ysql/YBManagedHostnameVerifier.java
@@ -42,6 +42,7 @@ public class YBManagedHostnameVerifier implements HostnameVerifier {
   protected Map<String, String> hostPortMapPublic = new HashMap<>();
   private final PGStream stream;
   private static Connection controlConnection = null;
+  private static String originalHost = null;
 
   public YBManagedHostnameVerifier(Properties props, PGStream stream){
     this.originalProperties = props;
@@ -112,7 +113,8 @@ public class YBManagedHostnameVerifier implements HostnameVerifier {
     originalProperties.setProperty("PGHOST", san);
     HostSpec[] hspec = hostSpecs(this.originalProperties);
     try {
-      if (controlConnection == null) {
+      if (controlConnection == null || ((PgConnection) controlConnection).getQueryExecutor().getHostSpec().getHost().equals(originalHost)) {
+        originalHost = san;
         controlConnection = new PgConnection(
             hspec, originalProperties.getProperty("user", ""), originalProperties.getProperty("PGDBNAME", ""), originalProperties, null);
       }

--- a/pgjdbc/src/main/java/com/yugabyte/ysql/YBjdbcHostnameVerifier.java
+++ b/pgjdbc/src/main/java/com/yugabyte/ysql/YBjdbcHostnameVerifier.java
@@ -1,0 +1,225 @@
+package com.yugabyte.ysql;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.PGStream;
+import org.postgresql.jdbc.PgConnection;
+import org.postgresql.ssl.PGjdbcHostnameVerifier;
+import org.postgresql.util.GT;
+import org.postgresql.util.HostSpec;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.postgresql.Driver.*;
+import static org.postgresql.util.internal.Nullness.castNonNull;
+
+public class YBjdbcHostnameVerifier implements HostnameVerifier {
+
+  private static final Logger LOGGER = Logger.getLogger(YBjdbcHostnameVerifier.class.getName());
+  protected static final String GET_SERVERS_QUERY = "select * from yb_servers()";
+  protected Boolean useHostColumn = null;
+
+
+
+
+  private static final int TYPE_DNS_NAME = 2;
+  private static final int TYPE_IP_ADDRESS = 7;
+  private final Properties originalProperties;
+  protected ArrayList<String> currentPublicIps = new ArrayList<>();
+  protected Map<String, String> hostPortMap = new HashMap<>();
+  protected Map<String, String> hostPortMapPublic = new HashMap<>();
+  private final PGStream stream;
+
+  public YBjdbcHostnameVerifier(Properties props, PGStream stream){
+    this.originalProperties = props;
+    this.stream= stream;
+
+  }
+
+  @Override
+  public boolean verify(String hostname, SSLSession session) {
+
+    X509Certificate[] peerCerts;
+    try {
+      peerCerts = (X509Certificate[]) session.getPeerCertificates();
+    } catch (SSLPeerUnverifiedException e) {
+      LOGGER.log(Level.SEVERE,
+          GT.tr("Unable to parse X509Certificate for hostname {0}", hostname), e);
+      return false;
+    }
+    if (peerCerts == null || peerCerts.length == 0) {
+      LOGGER.log(Level.SEVERE,
+          GT.tr("No certificates found for hostname {0}", hostname));
+      return false;
+    }
+
+    X509Certificate serverCert = peerCerts[0];
+
+    // Check for Subject Alternative Names (see RFC 6125)
+
+    Collection<List<?>> subjectAltNames;
+    try {
+      subjectAltNames = serverCert.getSubjectAlternativeNames();
+      if (subjectAltNames == null) {
+        subjectAltNames = Collections.emptyList();
+      }
+    } catch (CertificateParsingException e) {
+      LOGGER.log(Level.SEVERE,
+          GT.tr("Unable to parse certificates for hostname {0}", hostname), e);
+      return false;
+    }
+
+    boolean anyDnsSan = false;
+    String san = null;
+    /*
+     * Each item in the SAN collection is a 2-element list.
+     * See {@link X509Certificate#getSubjectAlternativeNames}
+     * The first element in each list is a number indicating the type of entry.
+     */
+    for (List<?> sanItem : subjectAltNames) {
+      if (sanItem.size() != 2) {
+        continue;
+      }
+      Integer sanType = (Integer) sanItem.get(0);
+      if (sanType == null) {
+        // just in case
+        continue;
+      }
+      if (sanType != TYPE_IP_ADDRESS && sanType != TYPE_DNS_NAME) {
+        continue;
+      }
+      san = (String) sanItem.get(1);
+      if (sanType == TYPE_IP_ADDRESS && san != null && san.startsWith("*")) {
+        // Wildcards should not be present in the IP Address field
+        continue;
+      }
+      anyDnsSan |= sanType == TYPE_DNS_NAME;
+    }
+
+    Connection controlConnection = null;
+    originalProperties.setProperty("PGHOST", san);
+    HostSpec[] hspec = hostSpecs(this.originalProperties);
+    try {
+      controlConnection = new PgConnection(
+          hspec, originalProperties.getProperty("user", ""),originalProperties.getProperty("PGDBNAME", ""), originalProperties, null);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+
+    ArrayList<String> hostlist = new ArrayList<>();
+    try {
+      hostlist = getCurrentServers(controlConnection);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+    if(hostlist.contains(hostname))
+      return true;
+    else
+      return false;
+
+
+  }
+
+  protected ArrayList<String> getCurrentServers(Connection conn) throws SQLException {
+    Statement st = conn.createStatement();
+
+    ResultSet rs = st.executeQuery(GET_SERVERS_QUERY);
+    ArrayList<String> currentPrivateIps = new ArrayList<>();
+    String hostConnectedTo = ((PgConnection) conn).getQueryExecutor().getHostSpec().getHost();
+    InetAddress hostConnectedInetAddr;
+
+    boolean isIpv6Addresses = hostConnectedTo.contains(":");
+    if (isIpv6Addresses) {
+      hostConnectedTo = hostConnectedTo.replace("[", "").replace("]", "");
+    }
+
+    try {
+      hostConnectedInetAddr = InetAddress.getByName(hostConnectedTo);
+    } catch (UnknownHostException e) {
+      // This is totally unexpected. As the connection is already created on this host
+      throw new PSQLException(GT.tr("Unexpected UnknownHostException for ${0} ", hostConnectedTo),
+          PSQLState.UNKNOWN_STATE, e);
+    }
+
+    currentPublicIps.clear();
+    while (rs.next()) {
+      String host = rs.getString("host");
+      String publicHost = rs.getString("public_ip");
+      String port = rs.getString("port");
+      String cloud = rs.getString("cloud");
+      String region = rs.getString("region");
+      String zone = rs.getString("zone");
+      hostPortMap.put(host, port);
+      hostPortMapPublic.put(publicHost, port);
+      updateCurrentHostList(currentPrivateIps, host, publicHost, cloud, region, zone);
+      InetAddress hostInetAddr;
+      InetAddress publicHostInetAddr;
+      try {
+        hostInetAddr = InetAddress.getByName(host);
+      } catch (UnknownHostException e) {
+        // set the hostInet to null
+        hostInetAddr = null;
+      }
+      try {
+        publicHostInetAddr = !publicHost.isEmpty()
+            ? InetAddress.getByName(publicHost) : null;
+      } catch (UnknownHostException e) {
+        // set the publicHostInetAddr to null
+        publicHostInetAddr = null;
+      }
+      if (useHostColumn == null) {
+        if (hostConnectedInetAddr.equals(hostInetAddr)) {
+          useHostColumn = Boolean.TRUE;
+        } else if (hostConnectedInetAddr.equals(publicHostInetAddr)) {
+          useHostColumn = Boolean.FALSE;
+        }
+      }
+    }
+    return getPrivateOrPublicServers(currentPrivateIps, currentPublicIps);
+  }
+  protected ArrayList<String> getPrivateOrPublicServers(ArrayList<String> privateHosts,
+      ArrayList<String> publicHosts) {
+    if (useHostColumn == null) {
+      if (publicHosts.isEmpty()) {
+        useHostColumn = Boolean.TRUE;
+      }
+
+      return privateHosts;
+    }
+    ArrayList<String> currentHosts = useHostColumn ? privateHosts : publicHosts
+    return currentHosts;
+  }
+
+  protected void updateCurrentHostList(ArrayList<String> currentPrivateIps, String host,
+      String publicIp, String cloud, String region, String zone) {
+    currentPrivateIps.add(host);
+    if (!publicIp.trim().isEmpty()) {
+      currentPublicIps.add(publicIp);
+    }
+  }
+  private static HostSpec[] hostSpecs(Properties props) {
+    String[] hosts = castNonNull(props.getProperty("PGHOST")).split(",");
+    String[] ports = castNonNull(props.getProperty("PGPORT")).split(",");
+    String localSocketAddress = props.getProperty("localSocketAddress");
+    HostSpec[] hostSpecs = new HostSpec[hosts.length];
+    for (int i = 0; i < hostSpecs.length; ++i) {
+      hostSpecs[i] = new HostSpec(hosts[i], Integer.parseInt(ports[i]), localSocketAddress);
+    }
+    return hostSpecs;
+  }
+}

--- a/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
@@ -5,7 +5,7 @@
 
 package org.postgresql.ssl;
 
-import com.yugabyte.ysql.YBjdbcHostnameVerifier;
+import com.yugabyte.ysql.YBManagedHostnameVerifier;
 
 import org.postgresql.PGProperty;
 import org.postgresql.core.PGStream;
@@ -64,8 +64,9 @@ public class MakeSSL extends ObjectFactory {
     if (sslhostnameverifier == null) {
       hvn = PGjdbcHostnameVerifier.INSTANCE;
       sslhostnameverifier = "PgjdbcHostnameVerifier";
-    }else if(sslhostnameverifier.equalsIgnoreCase("YBjdbcHostnameVerifier")){
-      hvn = new YBjdbcHostnameVerifier(info,stream);
+    }
+    else if (sslhostnameverifier.equalsIgnoreCase("com.yugabyte.ysql.YBManagedHostnameVerifier")){
+      hvn = new YBManagedHostnameVerifier(info,stream);
     }
     else {
       try {

--- a/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
+++ b/pgjdbc/src/main/java/org/postgresql/ssl/MakeSSL.java
@@ -5,6 +5,8 @@
 
 package org.postgresql.ssl;
 
+import com.yugabyte.ysql.YBjdbcHostnameVerifier;
+
 import org.postgresql.PGProperty;
 import org.postgresql.core.PGStream;
 import org.postgresql.core.SocketFactoryFactory;
@@ -62,7 +64,10 @@ public class MakeSSL extends ObjectFactory {
     if (sslhostnameverifier == null) {
       hvn = PGjdbcHostnameVerifier.INSTANCE;
       sslhostnameverifier = "PgjdbcHostnameVerifier";
-    } else {
+    }else if(sslhostnameverifier.equalsIgnoreCase("YBjdbcHostnameVerifier")){
+      hvn = new YBjdbcHostnameVerifier(info,stream);
+    }
+    else {
       try {
         hvn = (HostnameVerifier) instantiate(sslhostnameverifier, info, false, null);
       } catch (Exception e) {


### PR DESCRIPTION
This is a custom hostnameverifier for YBM SSL Connectivity in case of an external load balancer being present. In such a case, the root.crt carries only the IP address of the load balancer. When connections are made with other hosts in `verify-full` mode, the verification fails. 

This verifier makes connectiion to the cluster using the host present in the root.crt and gets a list of nodes in that cluster. Then it checks if the connecting host is present in the list of nodes or not, to verify SSL.