### PR TITLE
Fix portNumber issue when call BaseDataSource#getUrl

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
+++ b/pgjdbc/src/main/java/org/postgresql/ds/common/BaseDataSource.java
@@ -1274,8 +1274,8 @@ public abstract class BaseDataSource implements CommonDataSource, Referenceable 
     } else {
       url.append(serverName);
     }
-    if (portNumber != 0) {
-      url.append(":").append(portNumber);
+    if (getPortNumber() != 0) {
+      url.append(":").append(getPortNumber());
     }
     String moreEndPoints = getAdditionalEndPoints();
     if (moreEndPoints != null) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

web application using Spring and apache tomcat with data-source config by (apache tomcat resource) JNDI lookup

context.xml
```XML
<Resource name="jdbc/mydb"
	auth="Container"
	factory="com.zaxxer.hikari.HikariJNDIFactory"
	type="javax.sql.DataSource"
	idleTimeout="300000"
	minimumIdle="2" 
	maximumPoolSize="50"
	connectionTimeout="5000"
	leakDetectionThreshold="30000"
	dataSourceClassName="com.yugabyte.ysql.YBClusterAwareDataSource"
	dataSource.url="jdbc:yugabytedb://localhost:35433/mydb?load-balance=true"
	dataSource.user="postgres"
	dataSource.password="postgres"
	poolName="mydbDSPool"/>
```

MyDatasourceConfiguration.java
```JAVA
public class MyDatasourceConfiguration {

    @Value("${spring.datasource.jndi-name:app}")
    private String datasourceJndiName;

    @Bean
    public DataSource dataSource() throws NamingException {
        final JndiTemplate jndi = new JndiTemplate();
        return (DataSource) jndi.lookup("java:comp/env/jdbc/" + datasourceJndiName);
    }

}
```
When the application starts BaseDataSource#getUrl was returning

```
jdbc:yugabytedb://localhost/myd?adaptiveFetch=false&adaptiveFetchMaximum=-1&adaptiveFetchMinimum=0&allowEncodingChanges=false&ApplicationName=PostgreSQL+JDBC+Driver&autosave=never&binaryTransfer=true&binaryTransferDisable=&binaryTransferEnable=&cancelSignalTimeout=10&cleanupSavepoints=false&connectTimeout=10&databaseMetadataCacheFields=65536&databaseMetadataCacheFieldsMiB=5&defaultRowFetchSize=0&disableColumnSanitiser=false&escapeSyntaxCallMode=select&gssEncMode=allow&gsslib=auto&hideUnprivilegedObjects=false&hostRecheckSeconds=10&jaasLogin=true&loadBalanceHosts=false&loginTimeout=5&logServerErrorDetail=true&logUnclosedConnections=false&preferQueryMode=extended&preparedStatementCacheQueries=256&preparedStatementCacheSizeMiB=5&prepareThreshold=5&quoteReturningIdentifiers=true&readOnly=false&readOnlyMode=transaction&receiveBufferSize=-1&load-balance=true&reWriteBatchedInserts=false&sendBufferSize=-1&socketTimeout=0&sspiServiceClass=POSTGRES&targetServerType=any&tcpKeepAlive=false&tcpNoDelay=false&unknownLength=2147483647&useSpnego=false&xmlFactoryFactory=
```

instead: 
```
jdbc:yugabytedb://localhost:35433/myd?adaptiveFetch=false&adaptiveFetchMaximum=-1&adaptiveFetchMinimum=0&allowEncodingChanges=false&ApplicationName=PostgreSQL+JDBC+Driver&autosave=never&binaryTransfer=true&binaryTransferDisable=&binaryTransferEnable=&cancelSignalTimeout=10&cleanupSavepoints=false&connectTimeout=10&databaseMetadataCacheFields=65536&databaseMetadataCacheFieldsMiB=5&defaultRowFetchSize=0&disableColumnSanitiser=false&escapeSyntaxCallMode=select&gssEncMode=allow&gsslib=auto&hideUnprivilegedObjects=false&hostRecheckSeconds=10&jaasLogin=true&loadBalanceHosts=false&loginTimeout=5&logServerErrorDetail=true&logUnclosedConnections=false&preferQueryMode=extended&preparedStatementCacheQueries=256&preparedStatementCacheSizeMiB=5&prepareThreshold=5&quoteReturningIdentifiers=true&readOnly=false&readOnlyMode=transaction&receiveBufferSize=-1&load-balance=true&reWriteBatchedInserts=false&sendBufferSize=-1&socketTimeout=0&sspiServiceClass=POSTGRES&targetServerType=any&tcpKeepAlive=false&tcpNoDelay=false&unknownLength=2147483647&useSpnego=false&xmlFactoryFactory=
```
