### PR TITLE
Add a provision in driver to try another server on login timeout

### DIFF
--- a/pgjdbc/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
+++ b/pgjdbc/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
@@ -110,7 +110,7 @@ public class ClusterAwareLoadBalancer {
     int min = Integer.MAX_VALUE;
     ArrayList<String> minConnectionsHostList = new ArrayList<>();
     for (String h : hostToNumConnMap.keySet()) {
-      boolean wasTimedOutHost = timedOutHosts != null && timedOutHosts.contains(h) ? true : false;
+      boolean wasTimedOutHost = timedOutHosts != null && timedOutHosts.contains(h);
       if (failedHosts.contains(h) || wasTimedOutHost) {
         LOGGER.fine("Skipping failed host " + h + "(was timed out host=" + wasTimedOutHost +")");
         continue;

--- a/pgjdbc/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
+++ b/pgjdbc/src/main/java/com/yugabyte/ysql/ClusterAwareLoadBalancer.java
@@ -87,7 +87,7 @@ public class ClusterAwareLoadBalancer {
     return false;
   }
 
-  public synchronized String getLeastLoadedServer(List<String> failedHosts) {
+  public synchronized String getLeastLoadedServer(List<String> failedHosts, ArrayList<String> timedOutHosts) {
     LOGGER.fine("failedHosts: " + failedHosts + ", hostToNumConnMap: " + hostToNumConnMap);
     if ((hostToNumConnMap.isEmpty() && currentPublicIps.isEmpty())
         || Boolean.getBoolean(EXPLICIT_FALLBACK_ONLY_KEY)) {
@@ -110,8 +110,9 @@ public class ClusterAwareLoadBalancer {
     int min = Integer.MAX_VALUE;
     ArrayList<String> minConnectionsHostList = new ArrayList<>();
     for (String h : hostToNumConnMap.keySet()) {
-      if (failedHosts.contains(h)) {
-        LOGGER.fine("Skipping failed host " + h);
+      boolean wasTimedOutHost = timedOutHosts != null && timedOutHosts.contains(h) ? true : false;
+      if (failedHosts.contains(h) || wasTimedOutHost) {
+        LOGGER.fine("Skipping failed host " + h + "(was timed out host=" + wasTimedOutHost +")");
         continue;
       }
       int currLoad = hostToNumConnMap.get(h);
@@ -155,7 +156,7 @@ public class ClusterAwareLoadBalancer {
           }
         }
         // base condition for this recursive call is useHostColumn != null
-        return getLeastLoadedServer(failedHosts);
+        return getLeastLoadedServer(failedHosts, timedOutHosts);
       }
     }
     LOGGER.log(Level.FINE,


### PR DESCRIPTION
[Jira link](https://yugabyte.atlassian.net/browse/DB-11628)
[gh-issue](https://github.com/yugabyte/yugabyte-db/issues/22725)

The driver is being enhanced to handle a connection timing out due to a busy server when login timeout is used by the user.
The timed out server is added to a temporary list which is ignored when the Connect Thread goes for the next attempt after timeout. This feature is enabled only when load-balance is set to true.

Testing:
Manually tested both the scenarios, i.e. directly using login timeout property in url and second by using login timeout property in url  and Hikari pool combination.
[ For now I just added temporary code to sleep during connection attempt to mimic an unresponsive server. Removed the test code as it was not standard. We will add a cleaner test hook to simulate this cleanly later ]  