### PR TITLE
Changed the Driver.java to accept postgres URL

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/Driver.java
+++ b/pgjdbc/src/main/java/org/postgresql/Driver.java
@@ -271,7 +271,7 @@ public class Driver implements java.sql.Driver {
     // get defaults
     Properties defaults;
 
-    if (!url.startsWith("jdbc:yugabytedb:")) {
+    if (!url.startsWith("jdbc:yugabytedb:") && !url.startsWith("jdbc:postgresql:")) {
       return null;
     }
     try {
@@ -599,11 +599,16 @@ public class Driver implements java.sql.Driver {
       urlArgs = url.substring(qPos + 1);
     }
 
-    if (!urlServer.startsWith("jdbc:yugabytedb:")) {
-      LOGGER.log(Level.FINE, "JDBC URL must start with \"jdbc:yugabytedb:\" but was: {0}", url);
+    String prefix;
+    if (urlServer.startsWith("jdbc:yugabytedb:")) {
+      prefix = "jdbc:yugabytedb:";
+    } else if (urlServer.startsWith("jdbc:postgresql:")) {
+      prefix = "jdbc:postgresql:";
+    } else {
+      LOGGER.log(Level.FINE, "JDBC URL must start with \"jdbc:yugabytedb:\" or \"jdbc:postgresql:\" but was: {0}", url);
       return null;
     }
-    urlServer = urlServer.substring("jdbc:yugabytedb:".length());
+    urlServer = urlServer.substring(prefix.length());
 
     if ("//".equals(urlServer) || "///".equals(urlServer)) {
       urlServer = "";


### PR DESCRIPTION
Summary
The driver previously accepted only jdbc:yugabytedb: URLs. That broke compatibility with tools and tests that still use the standard PostgreSQL subprotocol jdbc:postgresql:, and caused multiple DriverTest failures (No suitable driver, acceptsURL false for jdbc:postgresql: URLs).

This change treats both prefixes as valid: connection and URL parsing behave the same after the prefix is stripped.

Changes
org/postgresql/Driver.java

connect() — Return null only when the URL does not start with either jdbc:yugabytedb: or jdbc:postgresql:.
parseURL() — Detect which of the two supported prefixes is present, strip it with the correct length, and reject other URLs with an updated log message that mentions both allowed prefixes.
No change to wire protocol, authentication, or connection logic beyond prefix handling.
