### PR TITLE
Replaced the jdbc:postgresql URLs with jdbc:yugabytedb URLs

### DIFF
--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -75,19 +75,19 @@ class DriverTest {
     assertNotNull(drv);
 
     // These are always correct
-    verifyUrl(drv, "jdbc:postgresql:test", "localhost", "5432", "test");
-    verifyUrl(drv, "jdbc:postgresql://localhost/test", "localhost", "5432", "test");
-    verifyUrl(drv, "jdbc:postgresql://localhost,locahost2/test", "localhost,locahost2", "5432,5432", "test");
-    verifyUrl(drv, "jdbc:postgresql://localhost:5433,locahost2:5434/test", "localhost,locahost2", "5433,5434", "test");
-    verifyUrl(drv, "jdbc:postgresql://[::1]:5433,:5434,[::1]/test", "[::1],localhost,[::1]", "5433,5434,5432", "test");
-    verifyUrl(drv, "jdbc:postgresql://localhost/test?port=8888", "localhost", "8888", "test");
-    verifyUrl(drv, "jdbc:postgresql://localhost:5432/test", "localhost", "5432", "test");
-    verifyUrl(drv, "jdbc:postgresql://localhost:5432/test?dbname=test2", "localhost", "5432", "test2");
-    verifyUrl(drv, "jdbc:postgresql://127.0.0.1/anydbname", "127.0.0.1", "5432", "anydbname");
-    verifyUrl(drv, "jdbc:postgresql://127.0.0.1:5433/hidden", "127.0.0.1", "5433", "hidden");
-    verifyUrl(drv, "jdbc:postgresql://127.0.0.1:5433/hidden?port=7777", "127.0.0.1", "7777", "hidden");
-    verifyUrl(drv, "jdbc:postgresql://[::1]:5740/db", "[::1]", "5740", "db");
-    verifyUrl(drv, "jdbc:postgresql://[::1]:5740/my%20data%23base%251?loggerFile=C%3A%5Cdir%5Cfile.log", "[::1]", "5740", "my data#base%1");
+    verifyUrl(drv, "jdbc:yugabytedb:test", "localhost", "5432", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://localhost/test", "localhost", "5432", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://localhost,locahost2/test", "localhost,locahost2", "5432,5432", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://localhost:5433,locahost2:5434/test", "localhost,locahost2", "5433,5434", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://[::1]:5433,:5434,[::1]/test", "[::1],localhost,[::1]", "5433,5434,5432", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://localhost/test?port=8888", "localhost", "8888", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://localhost:5432/test", "localhost", "5432", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://localhost:5432/test?dbname=test2", "localhost", "5432", "test2");
+    verifyUrl(drv, "jdbc:yugabytedb://127.0.0.1/anydbname", "127.0.0.1", "5432", "anydbname");
+    verifyUrl(drv, "jdbc:yugabytedb://127.0.0.1:5433/hidden", "127.0.0.1", "5433", "hidden");
+    verifyUrl(drv, "jdbc:yugabytedb://127.0.0.1:5433/hidden?port=7777", "127.0.0.1", "7777", "hidden");
+    verifyUrl(drv, "jdbc:yugabytedb://[::1]:5740/db", "[::1]", "5740", "db");
+    verifyUrl(drv, "jdbc:yugabytedb://[::1]:5740/my%20data%23base%251?loggerFile=C%3A%5Cdir%5Cfile.log", "[::1]", "5740", "my data#base%1");
 
     // tests for service syntax
     URL urlFileProps = getClass().getResource("/pg_service/pgservicefileProps.conf");
@@ -96,27 +96,27 @@ class DriverTest {
         new SystemProperties(PGEnvironment.ORG_POSTGRESQL_PGSERVICEFILE.getName(), urlFileProps.getFile())
     ).execute(() -> {
       // correct cases
-      verifyUrl(drv, "jdbc:postgresql://?service=driverTestService1", "test-host1", "5444", "testdb1");
-      verifyUrl(drv, "jdbc:postgresql://?service=driverTestService1&host=other-host", "other-host", "5444", "testdb1");
-      verifyUrl(drv, "jdbc:postgresql:///?service=driverTestService1", "test-host1", "5444", "testdb1");
-      verifyUrl(drv, "jdbc:postgresql:///?service=driverTestService1&port=3333&dbname=other-db", "test-host1", "3333", "other-db");
-      verifyUrl(drv, "jdbc:postgresql://localhost:5432/test?service=driverTestService1", "localhost", "5432", "test");
-      verifyUrl(drv, "jdbc:postgresql://localhost:5432/test?port=7777&dbname=other-db&service=driverTestService1", "localhost", "7777", "other-db");
-      verifyUrl(drv, "jdbc:postgresql://[::1]:5740/?service=driverTestService1", "[::1]", "5740", "testdb1");
-      verifyUrl(drv, "jdbc:postgresql://:5740/?service=driverTestService1", "localhost", "5740", "testdb1");
-      verifyUrl(drv, "jdbc:postgresql://[::1]/?service=driverTestService1", "[::1]", "5432", "testdb1");
-      verifyUrl(drv, "jdbc:postgresql://localhost/?service=driverTestService2", "localhost", "5432", "testdb1");
+      verifyUrl(drv, "jdbc:yugabytedb://?service=driverTestService1", "test-host1", "5444", "testdb1");
+      verifyUrl(drv, "jdbc:yugabytedb://?service=driverTestService1&host=other-host", "other-host", "5444", "testdb1");
+      verifyUrl(drv, "jdbc:yugabytedb:///?service=driverTestService1", "test-host1", "5444", "testdb1");
+      verifyUrl(drv, "jdbc:yugabytedb:///?service=driverTestService1&port=3333&dbname=other-db", "test-host1", "3333", "other-db");
+      verifyUrl(drv, "jdbc:yugabytedb://localhost:5432/test?service=driverTestService1", "localhost", "5432", "test");
+      verifyUrl(drv, "jdbc:yugabytedb://localhost:5432/test?port=7777&dbname=other-db&service=driverTestService1", "localhost", "7777", "other-db");
+      verifyUrl(drv, "jdbc:yugabytedb://[::1]:5740/?service=driverTestService1", "[::1]", "5740", "testdb1");
+      verifyUrl(drv, "jdbc:yugabytedb://:5740/?service=driverTestService1", "localhost", "5740", "testdb1");
+      verifyUrl(drv, "jdbc:yugabytedb://[::1]/?service=driverTestService1", "[::1]", "5432", "testdb1");
+      verifyUrl(drv, "jdbc:yugabytedb://localhost/?service=driverTestService2", "localhost", "5432", "testdb1");
       // fail cases
-      assertFalse(drv.acceptsURL("jdbc:postgresql://?service=driverTestService2"));
+      assertFalse(drv.acceptsURL("jdbc:yugabytedb://?service=driverTestService2"));
     });
 
     // Badly formatted url's
     assertFalse(drv.acceptsURL("jdbc:postgres:test"));
-    assertFalse(drv.acceptsURL("jdbc:postgresql:/test"));
-    assertFalse(drv.acceptsURL("jdbc:postgresql:////"));
-    assertFalse(drv.acceptsURL("jdbc:postgresql:///?service=my data#base%1"));
-    assertFalse(drv.acceptsURL("jdbc:postgresql://[::1]:5740/my data#base%1"));
-    assertFalse(drv.acceptsURL("jdbc:postgresql://localhost/dbname?loggerFile=C%3A%5Cdir%5Cfile.%log"));
+    assertFalse(drv.acceptsURL("jdbc:yugabytedb:/test"));
+    assertFalse(drv.acceptsURL("jdbc:yugabytedb:////"));
+    assertFalse(drv.acceptsURL("jdbc:yugabytedb:///?service=my data#base%1"));
+    assertFalse(drv.acceptsURL("jdbc:yugabytedb://[::1]:5740/my data#base%1"));
+    assertFalse(drv.acceptsURL("jdbc:yugabytedb://localhost/dbname?loggerFile=C%3A%5Cdir%5Cfile.%log"));
     assertFalse(drv.acceptsURL("postgresql:test"));
     assertFalse(drv.acceptsURL("db"));
     assertFalse(drv.acceptsURL("jdbc:yugabytedb://localhost:5432a/test"));
@@ -198,22 +198,22 @@ class DriverTest {
         // testing that properties overriding priority is correct (POSITIVE cases)
         //
         // service=correct port
-        Connection con = DriverManager.getConnection(String.format("jdbc:postgresql://?service=%s", testService1));
+        Connection con = DriverManager.getConnection(String.format("jdbc:yugabytedb://?service=%s", testService1));
         assertNotNull(con);
         con.close();
         // service=wrong port; Properties=correct port
         Properties info = new Properties();
         info.setProperty("PGPORT", String.valueOf(TestUtil.getPort()));
-        con = DriverManager.getConnection(String.format("jdbc:postgresql://?service=%s", testService2), info);
+        con = DriverManager.getConnection(String.format("jdbc:yugabytedb://?service=%s", testService2), info);
         assertNotNull(con);
         con.close();
         // service=wrong port; Properties=wrong port; URL port=correct
         info.setProperty("PGPORT", wrongPort);
-        con = DriverManager.getConnection(String.format("jdbc:postgresql://:%s/?service=%s", TestUtil.getPort(), testService2), info);
+        con = DriverManager.getConnection(String.format("jdbc:yugabytedb://:%s/?service=%s", TestUtil.getPort(), testService2), info);
         assertNotNull(con);
         con.close();
         // service=wrong port; Properties=wrong port; URL port=wrong; URL argument=correct port
-        con = DriverManager.getConnection(String.format("jdbc:postgresql://:%s/?service=%s&port=%s", wrongPort, testService2, TestUtil.getPort()), info);
+        con = DriverManager.getConnection(String.format("jdbc:yugabytedb://:%s/?service=%s&port=%s", wrongPort, testService2, TestUtil.getPort()), info);
         assertNotNull(con);
         con.close();
 
@@ -222,7 +222,7 @@ class DriverTest {
         //
         // service=wrong port
         try {
-          con = DriverManager.getConnection(String.format("jdbc:postgresql://?service=%s", testService2));
+          con = DriverManager.getConnection(String.format("jdbc:yugabytedb://?service=%s", testService2));
           fail("Expected an SQLException because port is out of range");
         } catch (SQLException e) {
           // Expected exception.
@@ -230,7 +230,7 @@ class DriverTest {
         // service=correct port; Properties=wrong port
         info.setProperty("PGPORT", wrongPort);
         try {
-          con = DriverManager.getConnection(String.format("jdbc:postgresql://?service=%s", testService1), info);
+          con = DriverManager.getConnection(String.format("jdbc:yugabytedb://?service=%s", testService1), info);
           fail("Expected an SQLException because port is out of range");
         } catch (SQLException e) {
           // Expected exception.
@@ -238,14 +238,14 @@ class DriverTest {
         // service=correct port; Properties=correct port; URL port=wrong
         info.setProperty("PGPORT", String.valueOf(TestUtil.getPort()));
         try {
-          con = DriverManager.getConnection(String.format("jdbc:postgresql://:%s/?service=%s", wrongPort, testService1), info);
+          con = DriverManager.getConnection(String.format("jdbc:yugabytedb://:%s/?service=%s", wrongPort, testService1), info);
           fail("Expected an SQLException because port is out of range");
         } catch (SQLException e) {
           // Expected exception.
         }
         // service=correct port; Properties=correct port; URL port=correct; URL argument=wrong port
         try {
-          con = DriverManager.getConnection(String.format("jdbc:postgresql://:%s/?service=%s&port=%s", TestUtil.getPort(), testService1, wrongPort), info);
+          con = DriverManager.getConnection(String.format("jdbc:yugabytedb://:%s/?service=%s&port=%s", TestUtil.getPort(), testService1, wrongPort), info);
           fail("Expected an SQLException because port is out of range");
         } catch (SQLException e) {
           // Expected exception.
@@ -280,7 +280,7 @@ class DriverTest {
               PGEnvironment.ORG_POSTGRESQL_PGPASSFILE.getName(), tempPgPassFile.toString())
       ).execute(() -> {
         // password from .pgpass (correct)
-        Connection con = DriverManager.getConnection(String.format("jdbc:postgresql://%s:%s/%s?user=%s", TestUtil.getServer(), TestUtil.getPort(), TestUtil.getDatabase(), TestUtil.getUser()));
+        Connection con = DriverManager.getConnection(String.format("jdbc:yugabytedb://%s:%s/%s?user=%s", TestUtil.getServer(), TestUtil.getPort(), TestUtil.getDatabase(), TestUtil.getUser()));
         assertNotNull(con);
         con.close();
       });
@@ -317,7 +317,7 @@ class DriverTest {
           new SystemProperties(PGEnvironment.ORG_POSTGRESQL_PGSERVICEFILE.getName(), tempPgServiceFile.toString(), PGEnvironment.ORG_POSTGRESQL_PGPASSFILE.getName(), tempPgPassFile.toString())
       ).execute(() -> {
         // password from service (correct) and .pgpass (wrong)
-        Connection con = DriverManager.getConnection(String.format("jdbc:postgresql://?service=%s", testService1));
+        Connection con = DriverManager.getConnection(String.format("jdbc:yugabytedb://?service=%s", testService1));
         assertNotNull(con);
         con.close();
       });
@@ -357,7 +357,7 @@ class DriverTest {
         // password from java property (correct) and service (wrong) and .pgpass (wrong)
         Properties info = new Properties();
         PGProperty.PASSWORD.set(info, TestUtil.getPassword());
-        Connection con = DriverManager.getConnection(String.format("jdbc:postgresql://?service=%s", testService1), info);
+        Connection con = DriverManager.getConnection(String.format("jdbc:yugabytedb://?service=%s", testService1), info);
         assertNotNull(con);
         con.close();
       });
@@ -397,7 +397,7 @@ class DriverTest {
         //
         Properties info = new Properties();
         PGProperty.PASSWORD.set(info, wrongPassword);
-        Connection con = DriverManager.getConnection(String.format("jdbc:postgresql://?service=%s&password=%s", testService1, TestUtil.getPassword()), info);
+        Connection con = DriverManager.getConnection(String.format("jdbc:yugabytedb://?service=%s&password=%s", testService1, TestUtil.getPassword()), info);
         assertNotNull(con);
         con.close();
       });
@@ -417,7 +417,7 @@ class DriverTest {
    */
   @Test
   void connectFailover() throws Exception {
-    String url = "jdbc:postgresql://invalidhost.not.here," + TestUtil.getServer() + ":"
+    String url = "jdbc:yugabytedb://invalidhost.not.here," + TestUtil.getServer() + ":"
         + TestUtil.getPort() + "/" + TestUtil.getDatabase() + "?connectTimeout=5";
     Connection con = DriverManager.getConnection(url, TestUtil.getUser(), TestUtil.getPassword());
     assertNotNull(con);


### PR DESCRIPTION
DriverTest: Switched all valid JDBC URLs from jdbc:postgresql: to jdbc:yugabytedb: so they match the fork, which only accepts the jdbc:yugabytedb: subprotocol. Left intentionally invalid URLs unchanged (e.g. jdbc:postgres:test). 