### PR TITLE
Changes did to fix No driver found issue and port mismatch issue.

### DIFF
--- a/pgjdbc/src/main/resources/META-INF/services/java.sql.Driver
+++ b/pgjdbc/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,1 +1,1 @@
-org.postgresql.Driver
+com.yugabyte.Driver

--- a/pgjdbc/src/main/resources/META-INF/services/java.sql.Driver
+++ b/pgjdbc/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,1 +1,1 @@
-com.yugabyte.Driver
+org.postgresql.Driver

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/DriverTest.java
@@ -74,16 +74,16 @@ class DriverTest {
     Driver drv = new Driver();
     assertNotNull(drv);
 
-    // These are always correct
-    verifyUrl(drv, "jdbc:yugabytedb:test", "localhost", "5432", "test");
-    verifyUrl(drv, "jdbc:yugabytedb://localhost/test", "localhost", "5432", "test");
-    verifyUrl(drv, "jdbc:yugabytedb://localhost,locahost2/test", "localhost,locahost2", "5432,5432", "test");
+    // Default port expectations match Yugabyte fork (Driver.DEFAULT_PORT = 5433), not upstream PG 5432.
+    verifyUrl(drv, "jdbc:yugabytedb:test", "localhost", "5433", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://localhost/test", "localhost", "5433", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://localhost,locahost2/test", "localhost,locahost2", "5433,5433", "test");
     verifyUrl(drv, "jdbc:yugabytedb://localhost:5433,locahost2:5434/test", "localhost,locahost2", "5433,5434", "test");
-    verifyUrl(drv, "jdbc:yugabytedb://[::1]:5433,:5434,[::1]/test", "[::1],localhost,[::1]", "5433,5434,5432", "test");
+    verifyUrl(drv, "jdbc:yugabytedb://[::1]:5433,:5434,[::1]/test", "[::1],localhost,[::1]", "5433,5434,5433", "test");
     verifyUrl(drv, "jdbc:yugabytedb://localhost/test?port=8888", "localhost", "8888", "test");
     verifyUrl(drv, "jdbc:yugabytedb://localhost:5432/test", "localhost", "5432", "test");
     verifyUrl(drv, "jdbc:yugabytedb://localhost:5432/test?dbname=test2", "localhost", "5432", "test2");
-    verifyUrl(drv, "jdbc:yugabytedb://127.0.0.1/anydbname", "127.0.0.1", "5432", "anydbname");
+    verifyUrl(drv, "jdbc:yugabytedb://127.0.0.1/anydbname", "127.0.0.1", "5433", "anydbname");
     verifyUrl(drv, "jdbc:yugabytedb://127.0.0.1:5433/hidden", "127.0.0.1", "5433", "hidden");
     verifyUrl(drv, "jdbc:yugabytedb://127.0.0.1:5433/hidden?port=7777", "127.0.0.1", "7777", "hidden");
     verifyUrl(drv, "jdbc:yugabytedb://[::1]:5740/db", "[::1]", "5740", "db");
@@ -104,8 +104,8 @@ class DriverTest {
       verifyUrl(drv, "jdbc:yugabytedb://localhost:5432/test?port=7777&dbname=other-db&service=driverTestService1", "localhost", "7777", "other-db");
       verifyUrl(drv, "jdbc:yugabytedb://[::1]:5740/?service=driverTestService1", "[::1]", "5740", "testdb1");
       verifyUrl(drv, "jdbc:yugabytedb://:5740/?service=driverTestService1", "localhost", "5740", "testdb1");
-      verifyUrl(drv, "jdbc:yugabytedb://[::1]/?service=driverTestService1", "[::1]", "5432", "testdb1");
-      verifyUrl(drv, "jdbc:yugabytedb://localhost/?service=driverTestService2", "localhost", "5432", "testdb1");
+      verifyUrl(drv, "jdbc:yugabytedb://[::1]/?service=driverTestService1", "[::1]", "5433", "testdb1");
+      verifyUrl(drv, "jdbc:yugabytedb://localhost/?service=driverTestService2", "localhost", "5433", "testdb1");
       // fail cases
       assertFalse(drv.acceptsURL("jdbc:yugabytedb://?service=driverTestService2"));
     });
@@ -126,10 +126,10 @@ class DriverTest {
 
     // failover urls
     verifyUrl(drv, "jdbc:yugabytedb://localhost,127.0.0.1:5432/test", "localhost,127.0.0.1",
-        "5432,5432", "test");
+        "5433,5432", "test");
     verifyUrl(drv, "jdbc:yugabytedb://localhost:5433,127.0.0.1:5432/test", "localhost,127.0.0.1",
         "5433,5432", "test");
-    verifyUrl(drv, "jdbc:yugabytedb://[::1],[::1]:5432/db", "[::1],[::1]", "5432,5432", "db");
+    verifyUrl(drv, "jdbc:yugabytedb://[::1],[::1]:5432/db", "[::1],[::1]", "5433,5432", "db");
     verifyUrl(drv, "jdbc:yugabytedb://[::1]:5740,127.0.0.1:5432/db", "[::1],127.0.0.1", "5740,5432",
         "db");
   }

--- a/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
+++ b/pgjdbc/src/test/java/org/postgresql/test/jdbc2/optional/BaseDataSourceFailoverUrlsTest.java
@@ -21,7 +21,8 @@ import javax.naming.NamingException;
  */
 class BaseDataSourceFailoverUrlsTest {
 
-  private static final String DEFAULT_PORT = "5432";
+  /** Yugabyte fork default (see {@code org.postgresql.Driver}); upstream PostgreSQL uses 5432. */
+  private static final String DEFAULT_PORT = "5433";
 
   @Test
   void fullDefault() throws ClassNotFoundException, NamingException, IOException {


### PR DESCRIPTION
The pgjdbc fork needed two kinds of fixes: first, its JDBC SPI registration was pointing to com.yugabyte.Driver, which does not exist, so DriverManager could not discover the driver and tests failed with “No suitable driver found.” That was corrected to org.postgresql.Driver. Second, some tests still assumed upstream PostgreSQL behavior, so I updated the test URLs to jdbc:yugabytedb: and aligned default-port expectations to YugabyteDB’s 5433 where needed.
