### PR TITLE
Fix control-connection refresh loop that could hang connection creation

### DIFF
--- a/pgjdbc/src/main/java/com/yugabyte/ysql/LoadBalanceService.java
+++ b/pgjdbc/src/main/java/com/yugabyte/ysql/LoadBalanceService.java
@@ -519,7 +519,7 @@ public class LoadBalanceService {
           }
           // Retry until servers are available
           if (hosts.isEmpty()) {
-            LOGGER.fine("Failed to establish control connection to available servers");
+            LOGGER.warning("Failed to establish control connection to available servers");
             return null;
           } else {
             // Try the first host in the list (don't have to check least loaded one since it's

--- a/pgjdbc/src/main/java/com/yugabyte/ysql/LoadBalanceService.java
+++ b/pgjdbc/src/main/java/com/yugabyte/ysql/LoadBalanceService.java
@@ -488,6 +488,8 @@ public class LoadBalanceService {
             LOGGER.fine("Exception while refreshing: " + ex + ", " + ex.getSQLState());
             String failed = ((PgConnection) controlConnection).getQueryExecutor().getHostSpec().getHost();
             markAsFailed(uuid, failed);
+            // Drop the host we just failed to refresh against so we don't retry it indefinitely.
+            hosts.remove(failed);
           } else {
             String msg = hspec.length > 1 ? " and others" : "";
             LOGGER.fine("Exception while creating control connection to "
@@ -496,6 +498,19 @@ public class LoadBalanceService {
               hosts.remove(h.getHost());
             }
           }
+          // Release the failed/dirty control connection before dropping the reference, otherwise
+          // the underlying socket and server-side session are leaked on every retry.
+          if (controlConnection != null) {
+            try {
+              controlConnection.close();
+            } catch (SQLException closeEx) {
+              LOGGER.fine("Error while closing failed control connection: " + closeEx);
+            }
+          }
+          if (uuid != null) {
+            uuidToClusterInfoMap.get(uuid).setControlConnection(null);
+          }
+          controlConnection = null;
           if (PSQLState.UNDEFINED_FUNCTION.getState().equals(ex.getSQLState())) {
             LOGGER.warning("Received UNDEFINED_FUNCTION for yb_servers()" +
                 " (SQLState=42883). You may be using an older version of" +
@@ -506,17 +521,14 @@ public class LoadBalanceService {
           if (hosts.isEmpty()) {
             LOGGER.fine("Failed to establish control connection to available servers");
             return null;
-          } else if (!refreshFailed) {
+          } else {
             // Try the first host in the list (don't have to check least loaded one since it's
-            // just for the control connection)
+            // just for the control connection). This also advances off a host whose refresh
+            // failed, so we don't keep hammering the same node.
             HostSpec hs = new HostSpec(hosts.get(0), getPort(uuid, hosts.get(0)),
                 key.getProperties().getProperty("localSocketAddress"));
             hspec = new HostSpec[]{hs};
           }
-          if (uuid != null) {
-            uuidToClusterInfoMap.get(uuid).setControlConnection(null);
-          }
-          controlConnection = null;
         }
       }
     }


### PR DESCRIPTION
Jira: [DB-22367](https://yugabyte.atlassian.net/browse/DB-22367)

## Problem

`LoadBalanceService.checkAndRefresh()` can spin indefinitely while holding the `LoadBalanceService` **class monitor** when a node accepts TCP connections but consistently fails the `yb_servers()` refresh query — e.g. a node mid-reboot returning `57P01` ("terminating connection due to unexpected postmaster exit"), or a TCP proxy in front of an unhealthy DB.

Two defects on the refresh-failure path:

1. **Connection leak** — the failed/dirty control connection was only dereferenced (`controlConnection = null`), never `close()`d, leaking the socket and server-side session on every retry.
2. **Non-terminating loop** — the refresh-failure branch neither dropped the failed host from `hosts` nor advanced `hspec`, so it retried the same node forever. None of the `while (true)` exits (refresh success, `42883`/`UNDEFINED_FUNCTION`, `hosts.isEmpty()`) were reachable on this path.

Because `checkAndRefresh` is `static synchronized`, a single spinning thread holds the class monitor forever; every other thread creating a load-balanced connection then blocks on that monitor and eventually times out ("Connection attempt timed out"). The affected JVM only recovers on restart.

## Fix

- `close()` the control connection before nulling it, moved ahead of the `UNDEFINED_FUNCTION` early-return so that exit stops leaking too.
- On refresh failure, remove the failed host from `hosts` and advance `hspec` (the previous `else if (!refreshFailed)` becomes a plain `else`), so `hosts` shrinks every iteration and `hosts.isEmpty()` guarantees the loop terminates.

## Behavior change

On a refresh failure the driver now tries other hosts for the control connection instead of retrying the same node. This is the intended fix but does change retry semantics on that path.

## Testing

- `:jdbc-yugabytedb:compileJava` passes (Java 17); no new warnings from the changed file.
- Not yet exercised at runtime — the triggering condition (connection establishes but `yb_servers()` persistently fails) needs a simulated always-fail-refresh against a live cluster.

---
_automated · Claude Code (Opus 4.8 1M)_